### PR TITLE
Minor changes to the sample scripts.

### DIFF
--- a/ImageSamples/helloWorld-auto/helloworld-app.wb
+++ b/ImageSamples/helloWorld-auto/helloworld-app.wb
@@ -2,13 +2,13 @@
 #########################################################
 #  Specify organization name for Apps (Required)        #
 #########################################################
-builder organization --name Bluedata
+builder organization --name Sample
 
 #################### Catalog Metadata ########################################
-#  This section generates or loads catalog metadata json file                  #  
+#  This section generates or loads catalog metadata json file                  #
 #  Metadata includes: 			      			               #
 #         Identification info: Distro ID, Name, Desc                           #
-#         Supported roles: Example; Controller,worker,edge,gateway, custom     # 
+#         Supported roles: Example; Controller,worker,edge,gateway, custom     #
 #         Deployed services: All registered services with display link (y/n)   #
 #         Role to Service : Associate specific services to selected roles      #
 ##############################################################################
@@ -27,13 +27,13 @@ role add controller 1
 role add worker 0+
 
 ############## All registered services #########
-# All possible services running on any of the nodes. 
+# All possible services running on any of the nodes.
 # Display option creates a clickable link for that http based service
 ##################################################
 service add --srvcid httpd --name "HelloWorld" --scheme "http" --port 80 \
             --path "/" --display
 
-################## Role and Service Map ############## 
+################## Role and Service Map ##############
 # Define a deployment map by associating roles to services.
 # Given below is a default deployment map
 #################################################
@@ -42,7 +42,7 @@ clusterconfig assign --configid default --role controller                      \
                      --srvcids httpd
 
 #################### CONTAINER CONFIGURATION SCRIPT (STARTSCRIPT) #################################
-#  This section generates or loads the startscript that runs on each container                     # 
+#  This section generates or loads the startscript that runs on each container                     #
 #  during cluster creation or cluster expansion/shrinking                                          #
 #  Startscript performs operations including but not limited to :                                  #
 #       *  Copying and updating configuration files from metadata repo to containers               #
@@ -54,19 +54,19 @@ clusterconfig assign --configid default --role controller                      \
 ###################################################################################################
 
 ##########################   Required ####################
-# Configuration API helps keep bakward compatibility. New management features are enabled/disabled
-#  based on confiapi verison.   
+# Configuration API helps keep bakward compatibility. New management features
+# are enabled/disabled based on confiapi verison.
 ########################################################
-appconfig autogen --new --configapi 4
+appconfig autogen --new --configapi 6
 
 ############# Copy config files from metadata repo to container #############
-# These files are stored in a metadata repo until cluster creation 
+# These files are stored in a metadata repo until cluster creation
 # After a cluster is created, it will be copied to specified destinations
 ############
 appconfig autogen --pkgfile index.html --dest /var/www/html/index.html
 
 ########### Update files with runtime information ############
-# Replace template variables with runtime values 
+# Replace template variables with runtime values
 ###############################################################
 
 appconfig autogen --replace /var/www/html/index.html --pattern @@@@FQDN@@@@            \
@@ -84,9 +84,9 @@ appconfig autogen --replace /var/www/html/index.html    \
 # httpd install automatically creates a systemctl script
 
 ########### Service start commands #######################
-# Start the services, in the order specified, with defined relationships 
+# Start the services, in the order specified, with defined relationships
 ###############################
-appconfig autogen --srvcid httpd --sysv httpd
+appconfig autogen --srvcid httpd --sysctl httpd
 
 ################# Package app catalog in a tgz ##########################
 # This section generates app configuration bundle (appconfig.tgz)        #

--- a/ImageSamples/helloWorld-json/helloworld-app.wb
+++ b/ImageSamples/helloWorld-json/helloworld-app.wb
@@ -2,13 +2,13 @@
 #########################################################
 #  Specify organization name for Apps (Required)        #
 #########################################################
-builder organization --name Bluedata
+builder organization --name Sample
 
 #################### Catalog Metadata ########################################
-#  This section generates or loads catalog metadata json file                  #  
+#  This section generates or loads catalog metadata json file                  #
 #  Metadata includes: 			      			               #
 #         Identification info: Distro ID, Name, Desc                           #
-#         Supported roles: Example; Controller,worker,edge,gateway, custom     # 
+#         Supported roles: Example; Controller,worker,edge,gateway, custom     #
 #         Deployed services: All registered services with display link (y/n)   #
 #         Role to Service : Associate specific services to selected roles      #
 ##############################################################################
@@ -16,7 +16,7 @@ builder organization --name Bluedata
 catalog load --filepath helloworld-centos.json
 
 #################### CONTAINER CONFIGURATION SCRIPT (STARTSCRIPT) #################################
-#  This section generates or loads the startscript that runs on each container                     # 
+#  This section generates or loads the startscript that runs on each container                     #
 #  during cluster creation or cluster expansion/shrinking                                          #
 #  Startscript performs operations including but not limited to :                                  #
 #       *  Copying and updating configuration files from metadata repo to containers               #
@@ -29,18 +29,18 @@ catalog load --filepath helloworld-centos.json
 
 ##########################   Required ####################
 # Configuration API helps keep bakward compatibility. New management features are enabled/disabled
-#  based on confiapi verison.   
+#  based on confiapi verison.
 ########################################################
 appconfig autogen --new --configapi 4
 
 ############# Copy config files from metadata repo to container #############
-# These files are stored in a metadata repo until cluster creation 
+# These files are stored in a metadata repo until cluster creation
 # After a cluster is created, it will be copied to specified destinations
 ############
 appconfig autogen --pkgfile index.html --dest /var/www/html/index.html
 
 ########### Update files with runtime information ############
-# Replace template variables with runtime values 
+# Replace template variables with runtime values
 ###############################################################
 
 appconfig autogen --replace /var/www/html/index.html --pattern @@@@FQDN@@@@            \
@@ -58,7 +58,7 @@ appconfig autogen --replace /var/www/html/index.html    \
 # httpd install automatically creates a systemctl script
 
 ########### Service start commands #######################
-# Start the services, in the order specified, with defined relationships 
+# Start the services, in the order specified, with defined relationships
 ###############################
 appconfig autogen --srvcid httpd --sysv httpd
 

--- a/ImageSamples/helloWorld-manual/helloworld-app.wb
+++ b/ImageSamples/helloWorld-manual/helloworld-app.wb
@@ -2,13 +2,13 @@
 #########################################################
 #  Specify organization name for Apps (Required)        #
 #########################################################
-builder organization --name Bluedata
+builder organization --name Sample
 
 #################### Catalog Metadata ########################################
-#  This section generates or loads catalog metadata json file                  #  
+#  This section generates or loads catalog metadata json file                  #
 #  Metadata includes: 			      			               #
 #         Identification info: Distro ID, Name, Desc                           #
-#         Supported roles: Example; Controller,worker,edge,gateway, custom     # 
+#         Supported roles: Example; Controller,worker,edge,gateway, custom     #
 #         Deployed services: All registered services with display link (y/n)   #
 #         Role to Service : Associate specific services to selected roles      #
 ##############################################################################
@@ -16,7 +16,7 @@ builder organization --name Bluedata
 catalog load --filepath helloworld-centos.json
 
 #################### CONTAINER CONFIGURATION SCRIPT (STARTSCRIPT) #################################
-#  This section generates or loads the startscript that runs on each container                     # 
+#  This section generates or loads the startscript that runs on each container                     #
 #  during cluster creation or cluster expansion/shrinking                                          #
 #  Startscript performs operations including but not limited to :                                  #
 #       *  Copying and updating configuration files from metadata repo to containers               #


### PR DESCRIPTION
- Avoid naming organization as BlueData. For internal developers just set `USE_BDS_INTERNAL_ORGNAME=true` in your bash env and you don't have to uncomment the builder line. That way customers who executes the `wb` will be forced to set the organization name. Althouhg, for now I changed it to `Sample`.
- Config api Version 6 is supported now and is the latest version. 
- Appconfig autogeneration has two new options: 
    - `appconfig autogen --sourcefile <FILE>`
    - `appconfig autogen --srvcid <ID> --sysctl <SYSCTL>`: for registering SystemD start scripts. 